### PR TITLE
Fixes 'uninitialized constant Notify::Utils' in Notify.bubble

### DIFF
--- a/lib/notifaction/notify.rb
+++ b/lib/notifaction/notify.rb
@@ -4,7 +4,7 @@ class Notify
   # Display a notification bubble
   # @since 0.1.0
   def self.bubble(message, title)
-    if Utils.os == :macosx
+    if Notifaction::Utils.os == :macosx
       handler = Notifaction::Type::OSX.new
     else
       handler = Notifaction::Type::Linux.new
@@ -17,7 +17,7 @@ class Notify
   # Display a modal popup with a close button
   # @since 0.1.0
   def self.modal(message, title)
-    if Utils.os == :macosx
+    if Notifaction::Utils.os == :macosx
       handler = Notifaction::Type::OSX.new
     else
       handler = Notifaction::Type::Linux.new

--- a/lib/notifaction/version.rb
+++ b/lib/notifaction/version.rb
@@ -1,3 +1,3 @@
 module Notifaction
-  VERSION = "0.4.3".freeze
+  VERSION = "0.4.4".freeze
 end


### PR DESCRIPTION
`Utils.os` is not namespaced properly.